### PR TITLE
Add BOS token in HF completion

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -228,11 +228,13 @@ class JsonProgram(LLMGenerator):
     
 @memory.cache
 def hf_complete(prompt, model, tokenizer, max_length=1024, eos_token=None) -> str:
-    inputs = tokenizer.encode(prompt, return_tensors="pt", add_special_tokens=False).to("cuda")
+    inputs = tokenizer.encode(prompt, return_tensors="pt", add_special_tokens=True).to("cuda")
     outputs = model.generate(inputs, max_new_tokens=max_length, use_cache=True, do_sample=False, repetition_penalty=1.1)
     text_output = tokenizer.decode(outputs[0], skip_special_tokens=False)[len(prompt):]
     if eos_token and text_output.endswith(eos_token):
         text_output = text_output[: -len(eos_token)]
+    if text_output.startswith(tokenizer.bos_token):
+        text_output = text_output[len(tokenizer.bos_token):]
     return text_output
     
 


### PR DESCRIPTION
#2 finds different pass@1 results for mAInframer-7b compared to the one in the model card in https://huggingface.co/bloopai/mAInframer-7b (~4% vs original ~6%)

This PR fixes `hf_complete` to include the BOS token so the result can be reproduced

